### PR TITLE
ARXIVNG-204 implemented config-driven URL builder for base templates

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 """Provides application for development purposes."""
 
-from base.factory import create_web_app
+from arxiv.base.factory import create_web_app
 
 app = create_web_app()

--- a/arxiv/base/config.py
+++ b/arxiv/base/config.py
@@ -3,3 +3,27 @@
 import os
 
 SERVER_NAME = None
+
+ARXIV_TWITTER_URL = os.environ.get('ARXIV_TWITTER_URL',
+                                   'https://twitter.com/arxiv')
+ARXIV_SEARCH_BOX_URL = os.environ.get('SEARCH_BOX_URL', '/search')
+ARXIV_SEARCH_ADVANCED_URL = os.environ.get('ARXIV_SEARCH_ADVANCED_URL',
+                                           '/search/advanced')
+ARXIV_ACCOUNT_URL = os.environ.get('ACCOUNT_URL', '/user')
+ARXIV_LOGIN_URL = os.environ.get('LOGIN_URL', '/user/login')
+ARXIV_LOGOUT_URL = os.environ.get('LOGOUT_URL', '/user/logout')
+ARXIV_HOME_URL = os.environ.get('ARXIV_HOME_URL', 'https://arxiv.org')
+ARXIV_HELP_URL = os.environ.get('ARXIV_HELP_URL', '/help')
+ARXIV_CONTACT_URL = os.environ.get('ARXIV_CONTACT_URL', '/help/contact')
+ARXIV_BLOG_URL = os.environ.get('ARXIV_BLOG_URL',
+                                "https://blogs.cornell.edu/arxiv/")
+ARXIV_WIKI_URL = os.environ.get(
+    'ARXIV_WIKI_URL',
+    "https://confluence.cornell.edu/display/arxivpub/arXiv+Public+Wiki"
+)
+ARXIV_ACCESSIBILITY_URL = os.environ.get(
+    'ARXIV_ACCESSIBILITY_URL',
+    "mailto:web-accessibility@cornell.edu"
+)
+ARXIV_LIBRARY_URL = os.environ.get('ARXIV_LIBRARY_URL',
+                                   'https://library.cornell.edu')

--- a/arxiv/base/routes.py
+++ b/arxiv/base/routes.py
@@ -1,7 +1,7 @@
 """Provides routes for verifying base templates."""
 
-from typing import Any, Tuple
-from flask import Blueprint, render_template
+from typing import Any, Tuple, Callable, Dict
+from flask import Blueprint, render_template, current_app
 
 from arxiv import status
 
@@ -12,3 +12,14 @@ blueprint = Blueprint('ui', __name__, url_prefix='')
 def test_page() -> Tuple[dict, int, dict]:
     """Render the test page."""
     return render_template("base/base.html"), status.HTTP_200_OK, {}
+
+
+@blueprint.context_processor
+def config_url_builder() -> Dict[str, Callable]:
+    """Inject a configurable URL factory."""
+    def config_url(target: str) -> str:
+        """Generate a URL from this app's configuration."""
+        target = target.upper()
+        # Will raise a KeyError; that seems reasonable?
+        return current_app.config[f'ARXIV_{target}_URL']
+    return dict(config_url=config_url)

--- a/arxiv/base/routes.py
+++ b/arxiv/base/routes.py
@@ -21,5 +21,6 @@ def config_url_builder() -> Dict[str, Callable]:
         """Generate a URL from this app's configuration."""
         target = target.upper()
         # Will raise a KeyError; that seems reasonable?
-        return current_app.config[f'ARXIV_{target}_URL']
+        url: str = current_app.config[f'ARXIV_{target}_URL']
+        return url
     return dict(config_url=config_url)

--- a/arxiv/base/templates/base/footer.html
+++ b/arxiv/base/templates/base/footer.html
@@ -1,20 +1,20 @@
 <div class="columns" role="navigation" aria-label="Secondary">
   <div class="column">
     <ul class="nav-spaced">
-      <li><a href="/help/contact">Contact</a></li>
-      <li><a href="https://twitter.com/arxiv">Find us on Twitter</a></li>
+      <li><a href="{{ config_url('contact') }}">Contact</a></li>
+      <li><a href="{{ config_url('twitter') }}">Find us on Twitter</a></li>
     </ul>
   </div>
   <div class="column">
     <ul class="nav-spaced">
-      <li><a href="https://blogs.cornell.edu/arxiv/">Blog - the latest news</a></li>
-      <li><a href="https://confluence.cornell.edu/display/arxivpub/arXiv+Public+Wiki">Wiki - project documentation</a></li>
+      <li><a href="{{ config_url('blog') }}">Blog - the latest news</a></li>
+      <li><a href="{{ config_url('wiki') }}">Wiki - project documentation</a></li>
     </ul>
   </div>
   <div class="column">
     <ul class="nav-spaced">
-      <li><a href="mailto:web-accessibility@cornell.edu">Web Accessibility Help</a></li>
-      <li><a href="/help">Help with using arXiv</a></li>
+      <li><a href="{{ config_url('accessibility') }}">Web Accessibility Help</a></li>
+      <li><a href="{{ config_url('help') }}">Help with using arXiv</a></li>
     </ul>
   </div>
 </div>

--- a/arxiv/base/templates/base/header.html
+++ b/arxiv/base/templates/base/header.html
@@ -1,15 +1,15 @@
 <!-- contains Cornell logo and sponsor statement -->
 <div class="attribution level is-marginless" role="banner">
   <div class="level-left">
-    <a class="level-item" href="https://library.cornell.edu"><img src="{{ url_for('base.static', filename='images/CUL-reduced-white-SMALL.svg') }}" alt="Cornell University Library" width="300" aria-label="logo" /></a>
+    <a class="level-item" href="{{ config_url('library') }}"><img src="{{ url_for('base.static', filename='images/CUL-reduced-white-SMALL.svg') }}" alt="Cornell University Library" width="300" aria-label="logo" /></a>
   </div>
   <div class="level-right"><p class="sponsors level-item">We gratefully acknowledge support from<br /> the Simons Foundation and member institutions</p></div>
 </div>
 <!-- contains arXiv identity and search bar -->
 <div class="identity level is-marginless">
   <div class="level-left">
-    <h1 class="level-item"><a href="" aria-label="arxiv-logo">arXiv.org</a></h1>
+    <h1 class="level-item"><a href="{{ config_url('home') }}" aria-label="arxiv-logo">arXiv.org</a></h1>
   </div>
-  {{ macros.compactsearch('level-right') }}
+  {{ macros.compactsearch(config_url, 'level-right') }}
 </div> <!-- closes identity -->
-<div class="user-tools box is-pulled-right" role="navigation" aria-label="User menu"><a href="">Login</a> | <a href="">My Account</a> | <a href="">Logout</a></div>
+<div class="user-tools box is-pulled-right" role="navigation" aria-label="User menu"><a href="{{ config_url('login') }}">Login</a> | <a href="{{ config_url('account') }}">My Account</a> | <a href="{{ config_url('logout') }}">Logout</a></div>

--- a/arxiv/base/templates/base/macros.html
+++ b/arxiv/base/templates/base/macros.html
@@ -1,6 +1,6 @@
 {# macros to be available to all templates across arxiv #}
 
-{% macro compactsearch(alignstyle="level-right") -%}
+{% macro compactsearch(config_url, alignstyle="level-right") -%}
   {# Creates an inline search widget with one input box, a dropdown for field
     selection, a button, and two tiny help/advanced links. Can be wrapped with
     Bulma's level element to align vertically with other elements in the same
@@ -8,11 +8,11 @@
     within level wrapper, allowed values are level-left or level-right.
   #}
   <div class="search-block {{ alignstyle }}">
-    <form class="level-item">
+    <form class="level-item" method="GET" action="{{ config_url('search_box') }}">
       <div class="field has-addons">
         <div class="control">
           <input class="input is-small" type="text" name="query" placeholder="Search..." aria-label="Search term or terms" />
-          <p class="help"><a href="">Help</a> | <a href="">Advanced Search</a></p>
+          <p class="help"><a href="{{ config_url('help') }}">Help</a> | <a href="{{ config_url('search_advanced') }}">Advanced Search</a></p>
         </div>
         <div class="control">
           <div class="select is-small">

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,3 +4,4 @@ jsonschema==2.6.0
 mypy==0.560
 pylint==1.8.2
 coverage==4.4.2
+coveralls==1.2.0


### PR DESCRIPTION
@eawoods This is to address building URLs for things in the base templates. It seems that the biggest constraint on this functionality is that it needs to be possible to make changes to these URLs without touching code (since base will be almost everywhere). The most straightforward way to do this is via configuration. So in this implementation, a function called ``config_url(target: str) -> str`` gets injected into the template context; it looks for and returns a configuration variable called ``ARXIV_[TARGET]_URL``.