### PR TITLE
Update MathJax config to only target elements with "mathjax" class

### DIFF
--- a/arxiv/base/templates/base/head.html
+++ b/arxiv/base/templates/base/head.html
@@ -23,7 +23,7 @@
           inlineDelimiters: ["$","$"],
           multiLine: false,
           style: {
-            "font-size": "normal"',
+            "font-size": "normal",
             "border": ""
           }
         }

--- a/arxiv/base/templates/base/head.html
+++ b/arxiv/base/templates/base/head.html
@@ -13,6 +13,7 @@
       inlineMath: [ ['$','$'], ["\\(","\\)"] ],
       displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
       processEscapes: true,
+      processClass: 'mathjax',
       ignoreClass: 'ignore_mathjax'
     },
     TeX: {

--- a/arxiv/base/templates/base/head.html
+++ b/arxiv/base/templates/base/head.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="{{ url_for('base.static', filename='css/arxivstyle.css')}}" />
 <script type="text/x-mathjax-config">
   MathJax.Hub.Config({
+    messageStyle: "none",
     extensions: ["tex2jax.js"],
     jax: ["input/TeX", "output/HTML-CSS"],
     tex2jax: {

--- a/arxiv/base/templates/base/head.html
+++ b/arxiv/base/templates/base/head.html
@@ -13,8 +13,8 @@
       inlineMath: [ ['$','$'], ["\\(","\\)"] ],
       displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
       processEscapes: true,
-      ignoreClass: '[a-zA-Z1-9]*',
-      processClass: 'mathjax'
+      ignoreClass: '.*',
+      processClass: 'mathjax.*'
     },
     TeX: {
         extensions: ["AMSmath.js", "AMSsymbols.js", "noErrors.js"]

--- a/arxiv/base/templates/base/head.html
+++ b/arxiv/base/templates/base/head.html
@@ -13,8 +13,8 @@
       inlineMath: [ ['$','$'], ["\\(","\\)"] ],
       displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
       processEscapes: true,
-      processClass: 'mathjax',
-      ignoreClass: 'ignore_mathjax'
+      ignoreClass: '*',
+      processClass: 'mathjax'
     },
     TeX: {
         extensions: ["AMSmath.js", "AMSsymbols.js", "noErrors.js"]

--- a/arxiv/base/templates/base/head.html
+++ b/arxiv/base/templates/base/head.html
@@ -13,7 +13,7 @@
       inlineMath: [ ['$','$'], ["\\(","\\)"] ],
       displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
       processEscapes: true,
-      ignoreClass: '*',
+      ignoreClass: '[a-zA-Z1-9]*',
       processClass: 'mathjax'
     },
     TeX: {

--- a/arxiv/base/templates/base/head.html
+++ b/arxiv/base/templates/base/head.html
@@ -18,7 +18,15 @@
       processClass: 'mathjax.*'
     },
     TeX: {
-        extensions: ["AMSmath.js", "AMSsymbols.js", "noErrors.js"]
+        extensions: ["AMSmath.js", "AMSsymbols.js", "noErrors.js"],
+        noErrors: {
+          inlineDelimiters: ["$","$"],
+          multiLine: false,
+          style: {
+            "font-size": "normal"',
+            "border": ""
+          }
+        }
     },
     "HTML-CSS": { availableFonts: ["TeX"] }
   });


### PR DESCRIPTION
All other elements are skipped. Since we haven't introduced abstracts yet, the "mathjax" class has only been applied to the title in the search results.

This PR also introduces two other minor changes:

1. disable multi-line, black-bordered box around TeX could not be processed by MathJax; it now looks like the rest of the paragraph
2. hide grey rendering status box that appears at the bottom of the page on page load; it was distracting to some users and doesn't provide much useful feedback anyway. Note that it's also possible to disable the greying of the TeX elements that MathJax has queued to process, but I haven't made that change here. 