### PR TITLE
ARXIVNG-392 ARXIVNG-391 added logging module with reasonable defaults

### DIFF
--- a/arxiv/base/config.py
+++ b/arxiv/base/config.py
@@ -31,3 +31,5 @@ ARXIV_ACKNOWLEDGEMENT_URL = os.environ.get(
     'ARXIV_ACKNOWLEDGEMENT_URL',
     "https://confluence.cornell.edu/x/ALlRF"
 )
+
+ARXIV_BUSINESS_TZ = os.environ.get('ARXIV_BUSINESS_TZ', 'US/Eastern')

--- a/arxiv/base/globals.py
+++ b/arxiv/base/globals.py
@@ -1,0 +1,43 @@
+"""Helpers for working with Flask globals."""
+
+import os
+from typing import Optional, Union
+from flask import g, Flask
+from flask import current_app as flask_app
+import werkzeug
+
+
+def get_application_config(app: Flask = None) -> Union[dict, os._Environ]:
+    """
+    Get a configuration from the current app, or fall back to env.
+
+    Parameters
+    ----------
+    app : :class:`flask.Flask`
+
+    Returns
+    -------
+    dict-like
+        This is either the current Flask application configuration, or
+        ``os.environ``. Either of these should support the ``get()`` method.
+    """
+    # pylint: disable=protected-access
+    if app is not None:
+        if isinstance(app, Flask):
+            return app.config # type: ignore
+    if flask_app:    # Proxy object; falsey if there is no application context.
+        return flask_app.config # type: ignore
+    return os.environ
+
+
+def get_application_global() -> Optional[werkzeug.local.LocalProxy]:
+    """
+    Get the current application global proxy object.
+
+    Returns
+    -------
+    proxy or None
+    """
+    if g:
+        return g # type: ignore
+    return None

--- a/arxiv/base/globals.py
+++ b/arxiv/base/globals.py
@@ -1,4 +1,14 @@
-"""Helpers for working with Flask globals."""
+"""
+Helpers for working with Flask globals.
+
+Flask makes heavy use of proxy objects. Depending on the context in which code
+is being executed, many of the Flask globals will refer to different things
+(or sometimes nothing at all). It is nice to be able to write code without
+handling the various scenarios that this creates. That's what this module is
+for: instead of accessing proxies directly, the functions here will access
+proxies appropriately depending on the context, and return the appropriate
+object.
+"""
 
 import os
 from typing import Optional, Union
@@ -9,7 +19,7 @@ import werkzeug
 
 def get_application_config(app: Flask = None) -> Union[dict, os._Environ]:
     """
-    Get a configuration from the current app, or fall back to env.
+    Get a configuration from the current app, or fall back to os.env.
 
     Parameters
     ----------
@@ -24,9 +34,9 @@ def get_application_config(app: Flask = None) -> Union[dict, os._Environ]:
     # pylint: disable=protected-access
     if app is not None:
         if isinstance(app, Flask):
-            return app.config # type: ignore
+            return app.config   # type: ignore
     if flask_app:    # Proxy object; falsey if there is no application context.
-        return flask_app.config # type: ignore
+        return flask_app.config     # type: ignore
     return os.environ
 
 
@@ -39,5 +49,5 @@ def get_application_global() -> Optional[werkzeug.local.LocalProxy]:
     proxy or None
     """
     if g:
-        return g # type: ignore
+        return g    # type: ignore
     return None

--- a/arxiv/base/logging.py
+++ b/arxiv/base/logging.py
@@ -57,7 +57,7 @@ def getLogger(name: str, stream: IO = sys.stderr) -> logging.Logger:
 
     # Log messages should be in Eastern local time, for consistency with
     # classic CUL/Apache logs.
-    tz = timezone(config.get('TIMEZONE', 'US/Eastern'))
+    tz = timezone(config.get('ARXIV_BUSINESS_TZ', 'US/Eastern'))
     logging.Formatter.converter = lambda *args: datetime.now(tz=tz).timetuple()
 
     # Set the formats for log messages and asctime. We instantiate our own

--- a/arxiv/base/logging.py
+++ b/arxiv/base/logging.py
@@ -32,7 +32,7 @@ class RequestFormatter(logging.Formatter):
             request_id = None
         record.requestid = request_id   # type: ignore
         if 'paperid' not in record.__dict__:
-            record.paperid = 'null'
+            record.paperid = 'null'     # type: ignore
         return super().format(record)
 
 

--- a/arxiv/base/logging.py
+++ b/arxiv/base/logging.py
@@ -1,5 +1,16 @@
-"""Provides a logger factory with reasonable defaults."""
+"""
+Provides a logger factory with reasonable defaults.
 
+We need to be able to analyze application logs in a consistent way across all
+arXiv services. This module provides a :func:`.getLogger`, which works just
+like the builtin logging.getLogger, but with a simpler interface:
+``getLogger(name: str, stream: IO)``.
+
+It sets some defaults that should be applied consistently across all arXiv
+services (e.g. date formatting, overall message structure), so that we can
+parse application log messages in a consistent way.
+"""
+from typing import IO
 import logging
 import sys
 from datetime import datetime
@@ -23,7 +34,7 @@ class RequestFormatter(logging.Formatter):
         return super().format(record)
 
 
-def getLogger(name: str, stream=sys.stderr) -> logging.Logger:
+def getLogger(name: str, stream: IO = sys.stderr) -> logging.Logger:
     """
     Wrapper for :func:`logging.getLogger` that applies configuration.
 

--- a/arxiv/base/logging.py
+++ b/arxiv/base/logging.py
@@ -24,13 +24,15 @@ from arxiv.base.globals import get_application_config
 class RequestFormatter(logging.Formatter):
     """Logging formatter that adds the current request ID to the log record."""
 
-    def format(self, record):
+    def format(self, record: logging.LogRecord) -> str:
         """Attach the request ID from the request environ to the log record."""
         try:
             request_id = request.environ.get('request_id', None)
         except RuntimeError as e:
             request_id = None
-        record.requestid = request_id
+        record.requestid = request_id   # type: ignore
+        if 'paperid' not in record.__dict__:
+            record.paperid = 'null'
         return super().format(record)
 
 
@@ -61,7 +63,7 @@ def getLogger(name: str, stream: IO = sys.stderr) -> logging.Logger:
     # Set the formats for log messages and asctime. We instantiate our own
     # StreamHandler so that we can use RequestFormatter (above).
     fmt = ("application %(asctime)s - %(name)s - %(requestid)s"
-           " - %(levelname)s: \"%(message)s\"")
+           " - [arxiv:%(paperid)s] - %(levelname)s: \"%(message)s\"")
     datefmt = '%d/%b/%Y:%H:%M:%S %z'    # Used to format asctime.
     handler = logging.StreamHandler(stream)
     handler.setFormatter(RequestFormatter(fmt=fmt, datefmt=datefmt))

--- a/arxiv/base/tests/test_logging.py
+++ b/arxiv/base/tests/test_logging.py
@@ -50,3 +50,23 @@ class TestGetLogger(TestCase):
         self.assertIn('DEBUG', captured_value,
                       "Changing LOGLEVEL in the app config should change the"
                       " logger log level")
+
+    def test_paper_id_is_set(self):
+        """``paperid`` is included in the log data."""
+        stream = StringIO()
+        logger = logging.getLogger('foologger', stream)
+        logger.error('what', extra={'paperid': '1234'})
+        captured_value = stream.getvalue()
+        stream.close()
+        self.assertIn('arxiv:1234', captured_value,
+                      "Should include paper ID in log messages")
+
+    def test_paper_id_is_not_set(self):
+        """``paperid`` is not included in the log data."""
+        stream = StringIO()
+        logger = logging.getLogger('foologger', stream)
+        logger.error('what')
+        captured_value = stream.getvalue()
+        stream.close()
+        self.assertIn('arxiv:null', captured_value,
+                      "Paper ID should be null in log messages")

--- a/arxiv/base/tests/test_logging.py
+++ b/arxiv/base/tests/test_logging.py
@@ -1,0 +1,52 @@
+from unittest import TestCase, mock
+import sys
+from contextlib import contextmanager
+from io import StringIO
+
+import logging as pyLogging
+from arxiv.base import logging
+
+
+class TestGetLogger(TestCase):
+    """Test :func:`.logging.getLogger`."""
+
+    def test_get_logger_no_app_nor_request(self):
+        """There is no application nor request context."""
+        stream = StringIO()
+
+        logger = logging.getLogger('foologger', stream)
+        self.assertIsInstance(logger, pyLogging.Logger,
+                              "Should return a logging.Logger instance")
+
+        logger.error('foo')
+        captured_value = stream.getvalue()
+        stream.close()
+        self.assertIn('ERROR: "foo"', captured_value,
+                      "Should log normally even if request is not present")
+
+    @mock.patch('arxiv.base.logging.request')
+    def test_get_logger_with_request(self, mock_request):
+        """The request context is available."""
+        mock_request.environ = {'request_id': 'foo-id-1234'}
+        stream = StringIO()
+        logger = logging.getLogger('foologger', stream)
+        self.assertIsInstance(logger, pyLogging.Logger,
+                              "Should return a logging.Logger instance")
+        logger.error('foo')
+        captured_value = stream.getvalue()
+        stream.close()
+        self.assertIn('foo-id-1234', captured_value,
+                      "Should include request ID in log messages")
+
+    @mock.patch('arxiv.base.logging.get_application_config')
+    def test_config_sets_loglevel(self, mock_get_config):
+        """LOGLEVEL param in config controls log level."""
+        mock_get_config.return_value = {'LOGLEVEL': 10}
+        stream = StringIO()
+        logger = logging.getLogger('foologger', stream)
+        logger.debug('foo')
+        captured_value = stream.getvalue()
+        stream.close()
+        self.assertIn('DEBUG', captured_value,
+                      "Changing LOGLEVEL in the app config should change the"
+                      " logger log level")

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,3 +5,4 @@ mypy==0.560
 pylint==1.8.2
 coverage==4.4.2
 coveralls==1.2.0
+bleach==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='arxiv-base',
-    version='0.5',
+    version='0.5.1',
     packages=find_packages(exclude=['tests.*']),
     zip_safe=False,
     include_package_data=True


### PR DESCRIPTION
This adds the module ``arxiv.base.logging``, which provides a function ``getLogger`` -- it works just like the builtin ``logging.getLogger``, but with a simpler interface ( ``getLogger(name: str, stream: TextIO)`` ). It sets some defaults that should be applied consistently across all arXiv services, so that we can parse application log messages in a consistent way.