### PR TITLE
ARXIVNG-414 add fields to header search

### DIFF
--- a/arxiv/base/templates/base/macros.html
+++ b/arxiv/base/templates/base/macros.html
@@ -17,14 +17,24 @@
         <div class="control">
           <div class="select is-small">
             <select name="searchtype" aria-label="Field to search">
-              <option value='all' selected="selected">All fields</option>
-              <option value='title'>Title</option>
-              <option value='author'>Author</option>
-              <option value='abstract'>Abstract</option>
-              <option>arXiv ID</option>
+              <option value="all" selected="selected">All fields</option>
+              <option value="title">Title</option>
+              <option value="author">Author</option>
+              <option value="abstract">Abstract</option>
+              <option value="comments">Comments</option>
+              <option value="journal_ref">Journal reference</option>
+              <option value="acm_class">ACM classification</option>
+              <option value="msc_class">MSC classification</option>
+              <option value="report_num">Report number</option>
+              <option value="paper_id">arXiv identifier</option>
+              <option value="doi">DOI</option>
+              <option value="orcid">ORCID</option>
+              <option value="author_id">arXiv author ID</option>
+              <option value="help">Help pages</option>
             </select>
           </div>
         </div>
+        <input type="hidden" name="source" value="header">
         <button class="button is-small is-primary">Search</button>
       </div>
     </form>


### PR DESCRIPTION
For parity with classic search template header and simple search (plus help pages).

<img width="393" alt="screen shot 2018-04-12 at 1 32 37 pm" src="https://user-images.githubusercontent.com/17456668/38694123-d0bb34e8-3e56-11e8-9705-40a23e3fc6c9.png">
