### PR TITLE
Add license definitions to arxiv-base and simple test

### DIFF
--- a/arxiv/license.py
+++ b/arxiv/license.py
@@ -73,7 +73,7 @@ NO_LICENSE_TEXT = 'I do not certify that any of the above licenses apply'
 
 ASSUMED_LICENSE = LICENSES['http://arxiv.org/licenses/assumed-1991-2003/']
 
-# Historical license to updated/current license (old: new)
+# Historical license to updated/current license (old URI: new URI)
 TRANSLATED_LICENSES = {
     'http://creativecommons.org/licenses/by/3.0/':
     'http://creativecommons.org/licenses/by/4.0/',

--- a/arxiv/license.py
+++ b/arxiv/license.py
@@ -6,7 +6,7 @@ LICENSES = {
     'http://arxiv.org/licenses/nonexclusive-distrib/1.0/': {
         'uri': 'http://arxiv.org/licenses/nonexclusive-distrib/1.0/',
         'label': 'arXiv.org perpetual, non-exclusive license to '
-        'distribute this article',
+                 'distribute this article',
         'note': '(Minimal rights required by arXiv.org. Select this '
                 'unless you understand the implications of other '
                 'licenses)',
@@ -34,7 +34,7 @@ LICENSES = {
         'uri': 'http://creativecommons.org/licenses/by-nc-sa/4.0/',
         'order': 7,
         'label': 'Creative Commons Attribution-Noncommercial-ShareAlike '
-        ' license',
+                 'license',
         'is_current': True,
         'is_valid': True,
         'icon_uri': f'{LICENSE_ICON_BASE_URI}/by-nc-sa-4.0.png'},
@@ -70,7 +70,7 @@ LICENSES = {
     'http://creativecommons.org/licenses/by-nc-sa/3.0/': {
         'uri': 'http://creativecommons.org/licenses/by-nc-sa/3.0/',
         'label': 'Creative Commons Attribution-Noncommercial-ShareAlike '
-        'license',
+                 'license',
         'order': 3,
         'is_current': False,
         'is_valid': True,
@@ -83,7 +83,7 @@ LICENSES = {
         'order': 4,
         'is_current': False,
         'is_valid': True,
-        'icon_uri': "$icon_baseurl/publicdomain.png"
+        'icon_uri': f'{LICENSE_ICON_BASE_URI}/publicdomain.png'
     },
     'no_license': {
         'order': 99,
@@ -106,7 +106,7 @@ TRANSLATED_LICENSES = {
 
 CURRENT_LICENSES = {
     k: v for k, v in LICENSES.items()
-    if all(k in v for k in ('is_current', 'order')) and v['is_current']
+    if 'order' in v and 'is_current' in v and v['is_current']
 }
 
 # Current license URIs by display order

--- a/arxiv/license.py
+++ b/arxiv/license.py
@@ -3,8 +3,8 @@
 
 LICENSE_ICON_BASE_URI = '/icons/licenses'
 LICENSES = {
+    # key is the license URI
     'http://arxiv.org/licenses/nonexclusive-distrib/1.0/': {
-        'uri': 'http://arxiv.org/licenses/nonexclusive-distrib/1.0/',
         'label': 'arXiv.org perpetual, non-exclusive license to '
                  'distribute this article',
         'note': '(Minimal rights required by arXiv.org. Select this '
@@ -14,21 +14,18 @@ LICENSES = {
         'is_current': True,
     },
     'http://creativecommons.org/licenses/by/4.0/': {
-        'uri': 'http://creativecommons.org/licenses/by/4.0/',
         'label': 'Creative Commons Attribution license',
         'order': 5,
         'is_current': True,
         'icon_uri': f'{LICENSE_ICON_BASE_URI}/by-4.0.png'},
 
     'http://creativecommons.org/licenses/by-sa/4.0/': {
-        'uri': 'http://creativecommons.org/licenses/by-sa/4.0/',
         'order': 6,
         'label': 'Creative Commons Attribution-ShareAlike license',
         'is_current': True,
         'icon_uri': f'{LICENSE_ICON_BASE_URI}/by-sa-4.0.png'},
 
     'http://creativecommons.org/licenses/by-nc-sa/4.0/': {
-        'uri': 'http://creativecommons.org/licenses/by-nc-sa/4.0/',
         'order': 7,
         'label': 'Creative Commons Attribution-Noncommercial-ShareAlike '
                  'license',
@@ -36,7 +33,6 @@ LICENSES = {
         'icon_uri': f'{LICENSE_ICON_BASE_URI}/by-nc-sa-4.0.png'},
 
     'http://creativecommons.org/publicdomain/zero/1.0/': {
-        'uri': 'http://creativecommons.org/publicdomain/zero/1.0/',
         'label': 'Creative Commons Public Domain Declaration',
         'order': 8,
         'is_current': True,
@@ -44,7 +40,6 @@ LICENSES = {
     },
 
     'http://arxiv.org/licenses/assumed-1991-2003/': {
-        'uri': 'http://arxiv.org/licenses/assumed-1991-2003/',
         'label': 'Assumed arXiv.org perpetual, non-exclusive license to '
                  'distribute this article for submissions made before '
                  'January 2004',
@@ -53,7 +48,6 @@ LICENSES = {
     },
 
     'http://creativecommons.org/licenses/by/3.0/': {
-        'uri': 'http://creativecommons.org/licenses/by/3.0/',
         'label': 'Creative Commons Attribution license',
         'order': 2,
         'is_current': False,
@@ -61,7 +55,6 @@ LICENSES = {
     },
 
     'http://creativecommons.org/licenses/by-nc-sa/3.0/': {
-        'uri': 'http://creativecommons.org/licenses/by-nc-sa/3.0/',
         'label': 'Creative Commons Attribution-Noncommercial-ShareAlike '
                  'license',
         'order': 3,
@@ -69,7 +62,6 @@ LICENSES = {
         'icon_uri': f'{LICENSE_ICON_BASE_URI}/by-nc-sa-3.0.png'
     },
     'http://creativecommons.org/licenses/publicdomain/': {
-        'uri': 'http://creativecommons.org/licenses/publicdomain/',
         'label': 'Creative Commons Public Domain Declaration',
         'note': '(Suitable for US government employees, for example)',
         'order': 4,

--- a/arxiv/license.py
+++ b/arxiv/license.py
@@ -12,14 +12,12 @@ LICENSES = {
                 'licenses)',
         'order': 1,
         'is_current': True,
-        'is_valid': True,
     },
     'http://creativecommons.org/licenses/by/4.0/': {
         'uri': 'http://creativecommons.org/licenses/by/4.0/',
         'label': 'Creative Commons Attribution license',
         'order': 5,
         'is_current': True,
-        'is_valid': True,
         'icon_uri': f'{LICENSE_ICON_BASE_URI}/by-4.0.png'},
 
     'http://creativecommons.org/licenses/by-sa/4.0/': {
@@ -27,7 +25,6 @@ LICENSES = {
         'order': 6,
         'label': 'Creative Commons Attribution-ShareAlike license',
         'is_current': True,
-        'is_valid': True,
         'icon_uri': f'{LICENSE_ICON_BASE_URI}/by-sa-4.0.png'},
 
     'http://creativecommons.org/licenses/by-nc-sa/4.0/': {
@@ -36,7 +33,6 @@ LICENSES = {
         'label': 'Creative Commons Attribution-Noncommercial-ShareAlike '
                  'license',
         'is_current': True,
-        'is_valid': True,
         'icon_uri': f'{LICENSE_ICON_BASE_URI}/by-nc-sa-4.0.png'},
 
     'http://creativecommons.org/publicdomain/zero/1.0/': {
@@ -44,7 +40,6 @@ LICENSES = {
         'label': 'Creative Commons Public Domain Declaration',
         'order': 8,
         'is_current': True,
-        'is_valid': True,
         'icon_uri': f'{LICENSE_ICON_BASE_URI}/zero-1.0.png'
     },
 
@@ -55,7 +50,6 @@ LICENSES = {
                  'January 2004',
         'order': 9,
         'is_current': False,
-        'is_valid': True,
     },
 
     'http://creativecommons.org/licenses/by/3.0/': {
@@ -63,7 +57,6 @@ LICENSES = {
         'label': 'Creative Commons Attribution license',
         'order': 2,
         'is_current': False,
-        'is_valid': True,
         'icon_uri': f'{LICENSE_ICON_BASE_URI}/by-3.0.png'
     },
 
@@ -73,7 +66,6 @@ LICENSES = {
                  'license',
         'order': 3,
         'is_current': False,
-        'is_valid': True,
         'icon_uri': f'{LICENSE_ICON_BASE_URI}/by-nc-sa-3.0.png'
     },
     'http://creativecommons.org/licenses/publicdomain/': {
@@ -82,15 +74,10 @@ LICENSES = {
         'note': '(Suitable for US government employees, for example)',
         'order': 4,
         'is_current': False,
-        'is_valid': True,
         'icon_uri': f'{LICENSE_ICON_BASE_URI}/publicdomain.png'
-    },
-    'no_license': {
-        'order': 99,
-        'label': 'I do not certify that any of the above licenses apply',
-        'is_valid': False
     }
 }
+NO_LICENSE_TEXT = 'I do not certify that any of the above licenses apply'
 
 ASSUMED_LICENSE = LICENSES['http://arxiv.org/licenses/assumed-1991-2003/']
 

--- a/arxiv/license.py
+++ b/arxiv/license.py
@@ -1,0 +1,114 @@
+"""arXiv license definitions."""
+
+
+LICENSE_ICON_BASE_URI = '/icons/licenses'
+LICENSES = {
+    'http://arxiv.org/licenses/nonexclusive-distrib/1.0/': {
+        'uri': 'http://arxiv.org/licenses/nonexclusive-distrib/1.0/',
+        'label': 'arXiv.org perpetual, non-exclusive license to '
+        'distribute this article',
+        'note': '(Minimal rights required by arXiv.org. Select this '
+                'unless you understand the implications of other '
+                'licenses)',
+        'order': 1,
+        'is_current': True,
+        'is_valid': True,
+    },
+    'http://creativecommons.org/licenses/by/4.0/': {
+        'uri': 'http://creativecommons.org/licenses/by/4.0/',
+        'label': 'Creative Commons Attribution license',
+        'order': 5,
+        'is_current': True,
+        'is_valid': True,
+        'icon_uri': f'{LICENSE_ICON_BASE_URI}/by-4.0.png'},
+
+    'http://creativecommons.org/licenses/by-sa/4.0/': {
+        'uri': 'http://creativecommons.org/licenses/by-sa/4.0/',
+        'order': 6,
+        'label': 'Creative Commons Attribution-ShareAlike license',
+        'is_current': True,
+        'is_valid': True,
+        'icon_uri': f'{LICENSE_ICON_BASE_URI}/by-sa-4.0.png'},
+
+    'http://creativecommons.org/licenses/by-nc-sa/4.0/': {
+        'uri': 'http://creativecommons.org/licenses/by-nc-sa/4.0/',
+        'order': 7,
+        'label': 'Creative Commons Attribution-Noncommercial-ShareAlike '
+        ' license',
+        'is_current': True,
+        'is_valid': True,
+        'icon_uri': f'{LICENSE_ICON_BASE_URI}/by-nc-sa-4.0.png'},
+
+    'http://creativecommons.org/publicdomain/zero/1.0/': {
+        'uri': 'http://creativecommons.org/publicdomain/zero/1.0/',
+        'label': 'Creative Commons Public Domain Declaration',
+        'order': 8,
+        'is_current': True,
+        'is_valid': True,
+        'icon_uri': f'{LICENSE_ICON_BASE_URI}/zero-1.0.png'
+    },
+
+    'http://arxiv.org/licenses/assumed-1991-2003/': {
+        'uri': 'http://arxiv.org/licenses/assumed-1991-2003/',
+        'label': 'Assumed arXiv.org perpetual, non-exclusive license to '
+                 'distribute this article for submissions made before '
+                 'January 2004',
+        'order': 9,
+        'is_current': False,
+        'is_valid': True,
+    },
+
+    'http://creativecommons.org/licenses/by/3.0/': {
+        'uri': 'http://creativecommons.org/licenses/by/3.0/',
+        'label': 'Creative Commons Attribution license',
+        'order': 2,
+        'is_current': False,
+        'is_valid': True,
+        'icon_uri': f'{LICENSE_ICON_BASE_URI}/by-3.0.png'
+    },
+
+    'http://creativecommons.org/licenses/by-nc-sa/3.0/': {
+        'uri': 'http://creativecommons.org/licenses/by-nc-sa/3.0/',
+        'label': 'Creative Commons Attribution-Noncommercial-ShareAlike '
+        'license',
+        'order': 3,
+        'is_current': False,
+        'is_valid': True,
+        'icon_uri': f'{LICENSE_ICON_BASE_URI}/by-nc-sa-3.0.png'
+    },
+    'http://creativecommons.org/licenses/publicdomain/': {
+        'uri': 'http://creativecommons.org/licenses/publicdomain/',
+        'label': 'Creative Commons Public Domain Declaration',
+        'note': '(Suitable for US government employees, for example)',
+        'order': 4,
+        'is_current': False,
+        'is_valid': True,
+        'icon_uri': "$icon_baseurl/publicdomain.png"
+    },
+    'no_license': {
+        'order': 99,
+        'label': 'I do not certify that any of the above licenses apply',
+        'is_valid': False
+    }
+}
+
+ASSUMED_LICENSE = LICENSES['http://arxiv.org/licenses/assumed-1991-2003/']
+
+# Historical license to updated/current license (old: new)
+TRANSLATED_LICENSES = {
+    'http://creativecommons.org/licenses/by/3.0/':
+    'http://creativecommons.org/licenses/by/4.0/',
+    'http://creativecommons.org/licenses/by-nc-sa/3.0/':
+    'http://creativecommons.org/licenses/by-nc-sa/4.0/',
+    'http://creativecommons.org/licenses/publicdomain/':
+    'http://creativecommons.org/publicdomain/zero/1.0/'
+}
+
+CURRENT_LICENSES = {
+    k: v for k, v in LICENSES.items()
+    if all(k in v for k in ('is_current', 'order')) and v['is_current']
+}
+
+# Current license URIs by display order
+CURRENT_LICENSE_URIS = \
+    sorted(CURRENT_LICENSES, key=lambda x: CURRENT_LICENSES[x]['order'])

--- a/arxiv/tests/test_license.py
+++ b/arxiv/tests/test_license.py
@@ -1,0 +1,21 @@
+"""Tests for arXiv taxonomy module."""
+from unittest import TestCase
+from arxiv.license import LICENSES, CURRENT_LICENSE_URIS
+
+
+class TestLicense(TestCase):
+    """Tests for the arXiv license definitions."""
+
+    def test_current_license_uris(self):
+        """Tests for the current active licenses."""
+        self.assertListEqual(
+            CURRENT_LICENSE_URIS,
+            [
+                'http://arxiv.org/licenses/nonexclusive-distrib/1.0/',
+                'http://creativecommons.org/licenses/by/4.0/',
+                'http://creativecommons.org/licenses/by-sa/4.0/',
+                'http://creativecommons.org/licenses/by-nc-sa/4.0/',
+                'http://creativecommons.org/publicdomain/zero/1.0/'
+            ],
+            'current license URIs match'
+        )

--- a/arxiv/tests/test_license.py
+++ b/arxiv/tests/test_license.py
@@ -7,7 +7,7 @@ class TestLicense(TestCase):
     """Tests for the arXiv license definitions."""
 
     def test_current_license_uris(self):
-        """Tests for the current active licenses."""
+        """Regression test for the current active licenses."""
         self.assertListEqual(
             CURRENT_LICENSE_URIS,
             [
@@ -19,3 +19,17 @@ class TestLicense(TestCase):
             ],
             'current license URIs match'
         )
+
+    def test_licenses_are_valid(self):
+        """Test licenses contain required key/values."""
+        for uri, license in LICENSES.items():
+            self.assertIn('label', license)
+            self.assertTrue(license['label'])
+            self.assertIn('is_current', license)
+            self.assertIsInstance(license['is_current'], bool)
+            self.assertIn('order', license)
+            self.assertIsInstance(license['order'], int)
+            if 'icon_uri' in license:
+                self.assertTrue(license['icon_uri'])
+            if 'note' in license:
+                self.assertTrue(license['note'])


### PR DESCRIPTION
This is mostly a conversion of the essentials from `arxiv-lib:arXiv::Config::Licenses`.