### PR TITLE
Pre-release merge for base-0.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='arxiv-base',
-    version='0.6',
+    version='0.6.1',
     packages=find_packages(exclude=['tests.*']),
     zip_safe=False,
     include_package_data=True


### PR DESCRIPTION
Fixes:
- ARXIVNG-806: Move License information to arXiv-base
- ARXIVNG-849: Update base categories to include those without subject class