### PR TITLE
ARXIVNG-1059 enabled auth context in header template when user session is available

### DIFF
--- a/arxiv/base/templates/base/header.html
+++ b/arxiv/base/templates/base/header.html
@@ -13,6 +13,6 @@
   {{ macros.compactsearch('level-right') }}
 </div> <!-- closes identity -->
 
-<!--  # TODO: reintroduce this once we have access to the user's session.
-  <div class="user-tools box is-pulled-right" role="navigation" aria-label="User menu"><a href="{{ url_for('login') }}">Login</a> | <a href="{{ url_for('account') }}">My Account</a> | <a href="{{ url_for('logout') }}">Logout</a></div>
--->
+<div class="user-tools box is-pulled-right" role="navigation" aria-label="User menu">
+    {% if request.session and request.session.user %}Logged in as <strong>{{ request.session.user.username }}</strong> | <a href="{{ url_for('account') }}">My Account</a> | <a href="{{ url_for('logout') }}">Logout</a>{% else %}<a href="{{ url_for('login') }}">Login</a>{% endif %}
+</div>

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='arxiv-base',
-    version='0.9.2',
+    version='0.10.1',
     packages=[f'arxiv.{package}' for package
               in find_packages('arxiv', exclude=['*test*'])],
     zip_safe=False,


### PR DESCRIPTION
Note that ``arxiv.base`` does not (and should not) depend on ``arxiv.users``. The template is un-opinionated about how``request.session.user.username`` gets set. 

The best way to see this in action is to install arXiv base from this branch into another app (e.g. search), and make requests with an auth token. See https://github.com/cul-it/arxiv-auth#generating-auth-tokens

![image](https://user-images.githubusercontent.com/3451594/43923510-fe4671ba-9bef-11e8-902b-6193f0fee2f7.png)
