### PR TITLE
ARXIVNG-1127 ARXIVNG-1101 Alerting

### DIFF
--- a/arxiv/base/__init__.py
+++ b/arxiv/base/__init__.py
@@ -30,8 +30,16 @@ from typing import Optional, Any, Dict
 from flask import Blueprint, Flask, Blueprint
 from werkzeug.exceptions import NotFound
 
-from arxiv.base import exceptions, urls
+from arxiv.base import exceptions, urls, alerts
 from arxiv.base.converter import ArXivConverter
+
+
+def inject_get_alerts() -> dict:
+    return dict(get_alerts=alerts.get_alerts)
+
+
+def inject_get_hidden_alerts() -> dict:
+    return dict(get_hidden_alerts=alerts.get_hidden_alerts)
 
 
 class Base(object):
@@ -64,3 +72,6 @@ class Base(object):
         # Attach the external URL handler as a fallback for failed calls to
         # url_for().
         app.url_build_error_handlers.append(urls.external_url_handler)
+
+        app.context_processor(inject_get_alerts)
+        app.context_processor(inject_get_hidden_alerts)

--- a/arxiv/base/alerts.py
+++ b/arxiv/base/alerts.py
@@ -1,14 +1,14 @@
 """
-Support for typed flash messages.
+Support for typed flash alerts.
 
 Flask provides a `simple cookie-based flashing mechanism
 <http://flask.pocoo.org/docs/1.0/patterns/flashing/>`. This module extends
-that mechanism to support structured messages (i.e. dicts) and set
+that mechanism to support structured alerts (i.e. dicts) and set
 message categories/severity.
 
 .. note::
 
-   For security purposes, messages are not treated as safe in the template by
+   For security purposes, alerts are not treated as safe in the template by
    default. To treat a message as safe, use ``safe=True`` when generating the
    flash notification.
 
@@ -18,20 +18,20 @@ For example:
 .. code-block:: python
 
    from flask import url_for
-   from arxiv.base import messages
+   from arxiv.base import alerts
 
    def handle_request():
        ...
 
        help_url = url_for('help')
-       messages.flash_warning(f'This is a warning, see <a href="{help_url}">'
-                              f'the docs</a> for more information',
-                              title='Warning title', safe=True)
-       messages.flash_info('This is some info', title='Info title')
-       messages.flash_failure('This is a failure', title='Failure title')
-       messages.flash_success('This is a success', title='Success title')
-       messages.flash_warning('This is a warning that cannot be dismissed',
-                              dismissable=False)
+       alerts.flash_warning(f'This is a warning, see <a href="{help_url}">'
+                            f'the docs</a> for more information',
+                            title='Warning title', safe=True)
+       alerts.flash_info('This is some info', title='Info title')
+       alerts.flash_failure('This is a failure', title='Failure title')
+       alerts.flash_success('This is a success', title='Success title')
+       alerts.flash_warning('This is a warning that cannot be dismissed',
+                            dismissable=False)
 
 """
 
@@ -81,7 +81,7 @@ def flash_warning(message: str, title: Optional[str] = None,
     """
     Flash a warning message to the user.
 
-    Warnings are like info messages, but with a higher level of concern. For
+    Warnings are like info alerts, but with a higher level of concern. For
     example, this might be used to notify a user that an unintended consequence
     might be imminent.
 

--- a/arxiv/base/alerts.py
+++ b/arxiv/base/alerts.py
@@ -38,7 +38,7 @@ For example:
 
 """
 
-from typing import Optional, List, Tuple
+from typing import Optional, List, Tuple, Union
 from flask import flash, Markup, get_flashed_messages
 
 INFO = 'info'
@@ -48,8 +48,9 @@ SUCCESS = 'success'
 HIDDEN = 'hidden'
 
 
-def _flash_with(severity: str, message: str, title: Optional[str] = None,
-                dismissable: bool = True, safe: bool = False) -> None:
+def _flash_with(severity: str, message: Union[str, dict],
+                title: Optional[str] = None, dismissable: bool = True,
+                safe: bool = False) -> None:
     if safe:
         message = Markup(message)
     data = {'message': message, 'title': title, 'dismissable': dismissable}
@@ -206,10 +207,13 @@ def get_alerts(severity: Optional[str] = None) -> List[Tuple[str, dict]]:
         and the second element is the alert itself.
 
     """
+    alerts: List[Tuple[str, dict]]
     if severity is not None:
-        return get_flashed_messages(with_categories=True,
-                                    category_filter=[severity])
-    return get_flashed_messages(with_categories=True)
+        alerts = get_flashed_messages(with_categories=True,
+                                      category_filter=[severity])
+    else:
+        alerts = get_flashed_messages(with_categories=True)
+    return alerts
 
 
 def get_hidden_alerts(key: str) -> Optional[dict]:

--- a/arxiv/base/routes.py
+++ b/arxiv/base/routes.py
@@ -13,7 +13,7 @@ from arxiv import status
 from arxiv.base.exceptions import NotFound, Forbidden, Unauthorized, \
     MethodNotAllowed, RequestEntityTooLarge, BadRequest, InternalServerError
 
-from . import messages
+from . import alerts
 
 blueprint = Blueprint('ui', __name__, url_prefix='')
 
@@ -24,15 +24,15 @@ def test_page() -> Response:
     rendered = render_template("base/styleguide.html", pagetitle='Home')
     response = make_response(rendered, status.HTTP_200_OK)
 
-    # Demonstrate flash messages. To see these messages, reload the page.
+    # Demonstrate flash alerts. To see these alerts, reload the page.
     help_url = url_for('help')
-    messages.flash_warning(f'This is a warning, see <a href="{help_url}">the'
+    alerts.flash_warning(f'This is a warning, see <a href="{help_url}">the'
                            f' docs</a> for more information',
                            title='Warning title', safe=True)
-    messages.flash_info('This is some info', title='Info title')
-    messages.flash_failure('This is a failure', title='Failure title')
-    messages.flash_success('This is a success', title='Success title')
-    messages.flash_warning('This is a warning that cannot be dismissed',
+    alerts.flash_info('This is some info', title='Info title')
+    alerts.flash_failure('This is a failure', title='Failure title')
+    alerts.flash_success('This is a success', title='Success title')
+    alerts.flash_warning('This is a warning that cannot be dismissed',
                            dismissable=False)
     return response
 

--- a/arxiv/base/templates/base/base.html
+++ b/arxiv/base/templates/base/base.html
@@ -19,7 +19,7 @@
       <div class="container">
         <div class="content">
           <div class="notifications" role="alert">
-              {% with messages = get_flashed_messages(with_categories=true) %}
+              {% with messages = get_alerts() %}
                 {% if messages %}
                   {% for category, message in messages %}
                     <div class="notification is-{{ category }}">
@@ -28,7 +28,6 @@
                       <p>{{ message.message }}</p>
                     </div>
                   {% endfor %}
-
                 {% endif %}
               {% endwith %}
           </div>

--- a/arxiv/base/tests/test_alerts.py
+++ b/arxiv/base/tests/test_alerts.py
@@ -1,186 +1,186 @@
-"""Tests for :mod:`arxiv.base.messages`."""
+"""Tests for :mod:`arxiv.base.alerts`."""
 
 from unittest import TestCase, mock
 from flask import Markup
 
-from arxiv.base import messages
+from arxiv.base import alerts
 
 
 class TestFlashInfo(TestCase):
-    """Tests for :func:`messages.flash_info`."""
+    """Tests for :func:`alerts.flash_info`."""
 
-    @mock.patch(f'{messages.__name__}.flash')
+    @mock.patch(f'{alerts.__name__}.flash')
     def test_flash_message(self, mock_flash):
         """Just flash a simple message."""
-        messages.flash_info('The message')
+        alerts.flash_info('The message')
         (data, category), kwargs = mock_flash.call_args
         self.assertEqual(data['message'], 'The message')
         self.assertIsInstance(data['message'], str)
         self.assertTrue(data['dismissable'])
-        self.assertEqual(category, messages.INFO)
+        self.assertEqual(category, alerts.INFO)
 
-    @mock.patch(f'{messages.__name__}.flash')
+    @mock.patch(f'{alerts.__name__}.flash')
     def test_flash_message_no_dismiss(self, mock_flash):
         """Flash a simple message that can't be dismissed."""
-        messages.flash_info('The message', dismissable=False)
+        alerts.flash_info('The message', dismissable=False)
         (data, category), kwargs = mock_flash.call_args
         self.assertEqual(data['message'], 'The message')
         self.assertIsInstance(data['message'], str)
         self.assertFalse(data['dismissable'])
-        self.assertEqual(category, messages.INFO)
+        self.assertEqual(category, alerts.INFO)
 
-    @mock.patch(f'{messages.__name__}.flash')
+    @mock.patch(f'{alerts.__name__}.flash')
     def test_safe_flash_message(self, mock_flash):
         """Flash a simple message that is HTML-safe."""
-        messages.flash_info('The message', safe=True)
+        alerts.flash_info('The message', safe=True)
         (data, category), kwargs = mock_flash.call_args
         self.assertEqual(data['message'], 'The message')
         self.assertIsInstance(data['message'], Markup)
         self.assertTrue(data['dismissable'])
-        self.assertEqual(category, messages.INFO)
+        self.assertEqual(category, alerts.INFO)
 
-    @mock.patch(f'{messages.__name__}.flash')
+    @mock.patch(f'{alerts.__name__}.flash')
     def test_flash_message_with_title(self, mock_flash):
         """Just flash a simple message with a title."""
-        messages.flash_info('The message', title='Foo title')
+        alerts.flash_info('The message', title='Foo title')
         (data, category), kwargs = mock_flash.call_args
         self.assertEqual(data['message'], 'The message')
         self.assertEqual(data['title'], 'Foo title')
         self.assertTrue(data['dismissable'])
-        self.assertEqual(category, messages.INFO)
+        self.assertEqual(category, alerts.INFO)
         self.assertIsInstance(data['message'], str)
 
 
 class TestFlashWarning(TestCase):
-    """Tests for :func:`messages.flash_warning`."""
+    """Tests for :func:`alerts.flash_warning`."""
 
-    @mock.patch(f'{messages.__name__}.flash')
+    @mock.patch(f'{alerts.__name__}.flash')
     def test_flash_message(self, mock_flash):
         """Just flash a simple message."""
-        messages.flash_warning('The message')
+        alerts.flash_warning('The message')
         (data, category), kwargs = mock_flash.call_args
         self.assertEqual(data['message'], 'The message')
         self.assertIsInstance(data['message'], str)
         self.assertTrue(data['dismissable'])
-        self.assertEqual(category, messages.WARNING)
+        self.assertEqual(category, alerts.WARNING)
 
-    @mock.patch(f'{messages.__name__}.flash')
+    @mock.patch(f'{alerts.__name__}.flash')
     def test_flash_message_no_dismiss(self, mock_flash):
         """Flash a simple message that can't be dismissed."""
-        messages.flash_warning('The message', dismissable=False)
+        alerts.flash_warning('The message', dismissable=False)
         (data, category), kwargs = mock_flash.call_args
         self.assertEqual(data['message'], 'The message')
         self.assertIsInstance(data['message'], str)
         self.assertFalse(data['dismissable'])
-        self.assertEqual(category, messages.WARNING)
+        self.assertEqual(category, alerts.WARNING)
 
-    @mock.patch(f'{messages.__name__}.flash')
+    @mock.patch(f'{alerts.__name__}.flash')
     def test_safe_flash_message(self, mock_flash):
         """Flash a simple message that is HTML-safe."""
-        messages.flash_warning('The message', safe=True)
+        alerts.flash_warning('The message', safe=True)
         (data, category), kwargs = mock_flash.call_args
         self.assertEqual(data['message'], 'The message')
         self.assertIsInstance(data['message'], Markup)
         self.assertTrue(data['dismissable'])
-        self.assertEqual(category, messages.WARNING)
+        self.assertEqual(category, alerts.WARNING)
 
-    @mock.patch(f'{messages.__name__}.flash')
+    @mock.patch(f'{alerts.__name__}.flash')
     def test_flash_message_with_title(self, mock_flash):
         """Just flash a simple message with a title."""
-        messages.flash_warning('The message', title='Foo title')
+        alerts.flash_warning('The message', title='Foo title')
         (data, category), kwargs = mock_flash.call_args
         self.assertEqual(data['message'], 'The message')
         self.assertEqual(data['title'], 'Foo title')
         self.assertTrue(data['dismissable'])
-        self.assertEqual(category, messages.WARNING)
+        self.assertEqual(category, alerts.WARNING)
         self.assertIsInstance(data['message'], str)
 
 
 class TestFlashFailure(TestCase):
-    """Tests for :func:`messages.flash_failure`."""
+    """Tests for :func:`alerts.flash_failure`."""
 
-    @mock.patch(f'{messages.__name__}.flash')
+    @mock.patch(f'{alerts.__name__}.flash')
     def test_flash_message(self, mock_flash):
         """Just flash a simple message."""
-        messages.flash_failure('The message')
+        alerts.flash_failure('The message')
         (data, category), kwargs = mock_flash.call_args
         self.assertEqual(data['message'], 'The message')
         self.assertIsInstance(data['message'], str)
         self.assertTrue(data['dismissable'])
-        self.assertEqual(category, messages.FAILURE)
+        self.assertEqual(category, alerts.FAILURE)
 
-    @mock.patch(f'{messages.__name__}.flash')
+    @mock.patch(f'{alerts.__name__}.flash')
     def test_flash_message_no_dismiss(self, mock_flash):
         """Flash a simple message that can't be dismissed."""
-        messages.flash_failure('The message', dismissable=False)
+        alerts.flash_failure('The message', dismissable=False)
         (data, category), kwargs = mock_flash.call_args
         self.assertEqual(data['message'], 'The message')
         self.assertIsInstance(data['message'], str)
         self.assertFalse(data['dismissable'])
-        self.assertEqual(category, messages.FAILURE)
+        self.assertEqual(category, alerts.FAILURE)
 
-    @mock.patch(f'{messages.__name__}.flash')
+    @mock.patch(f'{alerts.__name__}.flash')
     def test_safe_flash_message(self, mock_flash):
         """Flash a simple message that is HTML-safe."""
-        messages.flash_failure('The message', safe=True)
+        alerts.flash_failure('The message', safe=True)
         (data, category), kwargs = mock_flash.call_args
         self.assertEqual(data['message'], 'The message')
         self.assertIsInstance(data['message'], Markup)
         self.assertTrue(data['dismissable'])
-        self.assertEqual(category, messages.FAILURE)
+        self.assertEqual(category, alerts.FAILURE)
 
-    @mock.patch(f'{messages.__name__}.flash')
+    @mock.patch(f'{alerts.__name__}.flash')
     def test_flash_message_with_title(self, mock_flash):
         """Just flash a simple message with a title."""
-        messages.flash_failure('The message', title='Foo title')
+        alerts.flash_failure('The message', title='Foo title')
         (data, category), kwargs = mock_flash.call_args
         self.assertEqual(data['message'], 'The message')
         self.assertEqual(data['title'], 'Foo title')
         self.assertTrue(data['dismissable'])
-        self.assertEqual(category, messages.FAILURE)
+        self.assertEqual(category, alerts.FAILURE)
         self.assertIsInstance(data['message'], str)
 
 
 class TestFlashSuccess(TestCase):
-    """Tests for :func:`messages.flash_success`."""
+    """Tests for :func:`alerts.flash_success`."""
 
-    @mock.patch(f'{messages.__name__}.flash')
+    @mock.patch(f'{alerts.__name__}.flash')
     def test_flash_message(self, mock_flash):
         """Just flash a simple message."""
-        messages.flash_success('The message')
+        alerts.flash_success('The message')
         (data, category), kwargs = mock_flash.call_args
         self.assertEqual(data['message'], 'The message')
         self.assertIsInstance(data['message'], str)
         self.assertTrue(data['dismissable'])
-        self.assertEqual(category, messages.SUCCESS)
+        self.assertEqual(category, alerts.SUCCESS)
 
-    @mock.patch(f'{messages.__name__}.flash')
+    @mock.patch(f'{alerts.__name__}.flash')
     def test_flash_message_no_dismiss(self, mock_flash):
         """Flash a simple message that can't be dismissed."""
-        messages.flash_success('The message', dismissable=False)
+        alerts.flash_success('The message', dismissable=False)
         (data, category), kwargs = mock_flash.call_args
         self.assertEqual(data['message'], 'The message')
         self.assertIsInstance(data['message'], str)
         self.assertFalse(data['dismissable'])
-        self.assertEqual(category, messages.SUCCESS)
+        self.assertEqual(category, alerts.SUCCESS)
 
-    @mock.patch(f'{messages.__name__}.flash')
+    @mock.patch(f'{alerts.__name__}.flash')
     def test_safe_flash_message(self, mock_flash):
         """Flash a simple message that is HTML-safe."""
-        messages.flash_success('The message', safe=True)
+        alerts.flash_success('The message', safe=True)
         (data, category), kwargs = mock_flash.call_args
         self.assertEqual(data['message'], 'The message')
         self.assertIsInstance(data['message'], Markup)
         self.assertTrue(data['dismissable'])
-        self.assertEqual(category, messages.SUCCESS)
+        self.assertEqual(category, alerts.SUCCESS)
 
-    @mock.patch(f'{messages.__name__}.flash')
+    @mock.patch(f'{alerts.__name__}.flash')
     def test_flash_message_with_title(self, mock_flash):
         """Just flash a simple message with a title."""
-        messages.flash_success('The message', title='Foo title')
+        alerts.flash_success('The message', title='Foo title')
         (data, category), kwargs = mock_flash.call_args
         self.assertEqual(data['message'], 'The message')
         self.assertEqual(data['title'], 'Foo title')
         self.assertTrue(data['dismissable'])
-        self.assertEqual(category, messages.SUCCESS)
+        self.assertEqual(category, alerts.SUCCESS)
         self.assertIsInstance(data['message'], str)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='arxiv-base',
-    version='0.11.1rc1',
+    version='0.11.1rc2',
     packages=[f'arxiv.{package}' for package
               in find_packages('arxiv', exclude=['*test*'])],
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='arxiv-base',
-    version='0.10.1rc2',
+    version='0.11.1rc1',
     packages=[f'arxiv.{package}' for package
               in find_packages('arxiv', exclude=['*test*'])],
     zip_safe=False,


### PR DESCRIPTION
ARXIVNG-1101 Renames ``arxiv.base.messages`` to ``arxiv.base.alerts``
ARXIVNG-1127 Introduces ``arxiv.base.alerts.flash_hidden``, which can be used to send small amounts of structured data across requests (e.g. on redirect).